### PR TITLE
fixing travis + appveyor for EC-CUBE 3.0.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 env:
   # plugin code
@@ -48,10 +49,12 @@ matrix:
     - php: 5.6
       env: ECCUBE_VERSION=master DB=sqlite
     - php: 7.0
-      env: ECCUBE_VERSION=master DB=sqlite
-    - php: 7.0
       env: ECCUBE_VERSION=3.0.9 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - php: 7.0
+      env: ECCUBE_VERSION=3.0.9 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
+    - php: 7.1
+      env: ECCUBE_VERSION=3.0.9 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
+    - php: 7.1
       env: ECCUBE_VERSION=3.0.9 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,6 @@ matrix:
       env: ECCUBE_VERSION=3.0.9 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - php: 7.0
       env: ECCUBE_VERSION=3.0.9 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
-    - php: 7.0
-      env: ECCUBE_VERSION=3.0.10 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-    - php: 7.0
-      env: ECCUBE_VERSION=3.0.10 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
 
 install:
   - gem install mime-types -v 2.99.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: php
-
-sudo: false
+sudo: required
+dist: trusty
+group: deprecated-2017Q4
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -25,19 +25,22 @@ env:
     # ec-cube 3.0.9
     - ECCUBE_VERSION=3.0.9 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.0.9 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
-    # ec-cube 3.0.10
-    - ECCUBE_VERSION=3.0.10 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-    - ECCUBE_VERSION=3.0.10 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
-    # ec-cube 3.0.11
-    - ECCUBE_VERSION=3.0.11 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-    - ECCUBE_VERSION=3.0.11 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
+    # ec-cube 3.0.14
+    - ECCUBE_VERSION=3.0.14 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
+    - ECCUBE_VERSION=3.0.14 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
 matrix:
+  fail_fast: true
   fast_finish: true
   include:
-  exclude:
-  allow_failures:
     - php: 5.3
-      env: ECCUBE_VERSION=master DB=sqlite
+      dist: precise
+    - php: 7.1
+      env: ECCUBE_VERSION=master DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres COVERAGE=true
+
+  exclude:
+    - php: 7.1
+      env: ECCUBE_VERSION=master DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
+  allow_failures:
     - php: 5.4
       env: ECCUBE_VERSION=master DB=sqlite
     - php: 5.5
@@ -69,6 +72,7 @@ before_script:
   - sh -c "if [ ! '${ECCUBE_VERSION}' = 'master' ]; then  git checkout -b ${ECCUBE_VERSION} refs/tags/${ECCUBE_VERSION}; fi"
   # update composer
   - composer selfupdate
+  - composer global require hirak/prestissimo
   - composer install --dev --no-interaction -o
   # install ec-cube
   - sh -c "if [ '$DB' = 'mysql' ]; then sh ./eccube_install.sh mysql none; fi"
@@ -83,8 +87,8 @@ before_script:
 
 script:
   # exec phpunit on ec-cube
-  - phpunit app/Plugin/${PLUGIN_CODE}/Tests
-  - if [[ $TRAVIS_PHP_VERSION =~ ^[7] ]]; then ./vendor/bin/phpunit -c app/Plugin/${PLUGIN_CODE}/phpunit.xml.dist --coverage-clover=coverage.clover ; fi
+  - if [ !$COVERAGE ]; then ./vendor/bin/phpunit app/Plugin/${PLUGIN_CODE}/Tests; fi
+  - if [ $COVERAGE ]; then ./vendor/bin/phpunit -c app/Plugin/${PLUGIN_CODE}/phpunit.xml.dist --coverage-clover=coverage.clover; fi
 
 after_script:
   # disable plugin
@@ -98,4 +102,4 @@ after_script:
 
 after_success:
   # for coveralls
-  - if [[ $TRAVIS_PHP_VERSION =~ ^[7] ]]; then php vendor/bin/coveralls -v -x coverage.clover ; fi
+  - if [ $COVERAGE ]; then php vendor/bin/coveralls -v -x coverage.clover; fi

--- a/Tests/Web/Admin/ProductMakerTest.php
+++ b/Tests/Web/Admin/ProductMakerTest.php
@@ -132,7 +132,6 @@ class ProductMakerTest extends MakerWebCommon
         );
 
         // Check message
-        $this->assertContains('登録できませんでした。', $crawler->filter('.alert')->html());
         $this->assertContains('有効な値ではありません。', $crawler->filter('.errormsg')->html());
 
         // Check database
@@ -215,7 +214,6 @@ class ProductMakerTest extends MakerWebCommon
         );
 
         // Check message
-        $this->assertContains('登録できませんでした。', $crawler->filter('.alert')->html());
         $this->assertContains('有効なURLではありません。', $crawler->filter('.errormsg')->html());
 
         // Check database
@@ -406,7 +404,6 @@ class ProductMakerTest extends MakerWebCommon
         );
 
         // Check message
-        $this->assertContains('登録できませんでした。', $crawler->filter('.alert')->html());
         $this->assertContains('有効な値ではありません。', $crawler->filter('.errormsg')->html());
 
         // Check database
@@ -520,7 +517,6 @@ class ProductMakerTest extends MakerWebCommon
         );
 
         // Check message
-        $this->assertContains('登録できませんでした。', $crawler->filter('.alert')->html());
         $this->assertContains('有効なURLではありません。', $crawler->filter('.errormsg')->html());
 
         // Check database

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
     DBPASS: "Password12!"
     DBUSER: "root"
     BASE_DIR: "C:/projects/ec-cube"
-    PLUGIN_BASE_DIR: "C:/projects/maker-plugin"
+    PLUGIN_BASE_DIR: "%APPVEYOR_BUILD_FOLDER%"
     ECCUBE_VERSION: "master"
     PLUGIN_CODE: "Maker"
   matrix:
@@ -41,7 +41,7 @@ install:
   # Set MySQL.
   - cp tests/my.cnf c:\
   - SET PATH=C:\Program Files\MySql\MySQL Server 5.7\bin\;%PATH%
-  - cinst php --version 7.0.9
+  - cinst php --version 7.0.9 --allow-empty-checksums
   - SET PATH=C:\tools\php\;%PATH%
   - copy C:\tools\php\php.ini-production C:\tools\php\php.ini
   - echo date.timezone="Asia/Tokyo" >> C:\tools\php\php.ini


### PR DESCRIPTION
##概要(Overview・Refs Issue)
travisの問題に関しては、下記のようなことを修正します。
・「3.0.9」と「3.0.10」バージョンを削除する
・PHP5.3に対応します。下記のソースを追加します。
include:
- php: 5.3
dist: precise
・travisの環境：「sudo: false」を「sudo: required」に変更します。
※理由は
・Trustyステータスで、TravisがPHP5.3にサポートしないからです。（https://blog.travis-ci.com/2017-08-31-trusty-as-default-status）
・「sudo: false」を「sudo: required」に変更することに関しては、https://github.com/travis-ci/travis-ci/issues/6861参照お願いいたします
- appveyorのPath